### PR TITLE
TASK: Make ReleaseHelpers.sh use new commit subject style

### DIFF
--- a/FilterStabilityFlags.php
+++ b/FilterStabilityFlags.php
@@ -1,15 +1,7 @@
 <?php
-/*                                                                        *
- * This script belongs to the TYPO3 Flow build system.                    *
- *                                                                        *
- * It is free software; you can redistribute it and/or modify it under    *
- * the terms of the GNU General Public License, either version 3 of the   *
- * License, or (at your option) any later version.                        *
- *                                                                        *
- * The TYPO3 project - inspiring people to share!                         *
- *                                                                        */
-
 /*
+ * This script belongs to the Flow build system.
+ *
  * This is a simple filter to remove any requirements that are
  * simply specifying a stability flag for a package in the typo3
  * vendor namespace.
@@ -36,5 +28,3 @@ if (version_compare(PHP_VERSION, '5.4.0', '<')) {
 } else {
 	file_put_contents('composer.json', json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 }
-
-?>

--- a/ReleaseHelpers.sh
+++ b/ReleaseHelpers.sh
@@ -8,9 +8,9 @@ function tag_version {
 	local DIR=$4
 
 	if [ -z "${DIR}" ] ; then
-		git tag -f -a -m "[TASK] Tag as version ${VERSION}" -m "See ${BUILD_URL}" ${VERSION}
+		git tag -f -a -m "TASK: Tag as version ${VERSION}" -m "See ${BUILD_URL}" ${VERSION}
 	else
-		git --git-dir "${DIR}/.git" tag -f -a -m "[TASK] Tag as version ${VERSION}" -m "See ${BUILD_URL}" ${VERSION}
+		git --git-dir "${DIR}/.git" tag -f -a -m "TASK: Tag as version ${VERSION}" -m "See ${BUILD_URL}" ${VERSION}
 	fi
 }
 
@@ -41,7 +41,7 @@ function commit_manifest_update {
 			if [[ `git status --porcelain "*/composer.json"` ]] ; then
 				git add */composer.json
 			fi
-			git commit -m "[TASK] Update composer manifest for ${VERSION}" -m "See ${BUILD_URL}"
+			git commit -m "TASK: Update composer manifest for ${VERSION}" -m "See ${BUILD_URL}"
 		fi
 	else
 		if [[ `git --git-dir "${DIR}/.git" --work-tree "${DIR}" status --porcelain composer.json "*/composer.json"` ]] ; then
@@ -51,7 +51,7 @@ function commit_manifest_update {
 			if [[ `git --git-dir "${DIR}/.git" --work-tree "${DIR}" status --porcelain "*/composer.json"` ]] ; then
 				git --git-dir "${DIR}/.git" --work-tree "${DIR}" add "*/composer.json"
 			fi
-			git --git-dir "${DIR}/.git" --work-tree "${DIR}" commit -m "[TASK] Update composer manifest for ${VERSION}" -m "See ${BUILD_URL}"
+			git --git-dir "${DIR}/.git" --work-tree "${DIR}" commit -m "TASK: Update composer manifest for ${VERSION}" -m "See ${BUILD_URL}"
 		fi
 	fi
 }


### PR DESCRIPTION
Instead of '[TASK]' it now uses 'TASK:'