### PR TITLE
TASK: Remove logIncompleteSkipped from PhpUnit configuration

### DIFF
--- a/PhpUnit/FunctionalTests.xml
+++ b/PhpUnit/FunctionalTests.xml
@@ -40,7 +40,7 @@
 		</whitelist>
 	</filter>
 	<logging>
-		<log type="junit" target="../../Reports/FunctionalTests.xml" logIncompleteSkipped="false"/>
+		<log type="junit" target="../../Reports/FunctionalTests.xml"/>
 		<log type="testdox-text" target="../../Reports/FunctionalTestDox.txt"/>
 	</logging>
 	<php>

--- a/PhpUnit/UnitTests.xml
+++ b/PhpUnit/UnitTests.xml
@@ -19,7 +19,7 @@
 		</whitelist>
 	</filter>
 	<logging>
-		<log type="junit" target="../../Reports/UnitTests.xml" logIncompleteSkipped="false"/>
+		<log type="junit" target="../../Reports/UnitTests.xml"/>
 	</logging>
 	<php>
 		<ini name="date.timezone" value="Africa/Tunis" />


### PR DESCRIPTION
This removes the warning with newer PhpUnit versions:

```
PHPUnit 7.5.1 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 22:
  - Element 'log', attribute 'logIncompleteSkipped': The attribute 'logIncompleteSkipped' is not allowed.

  Test results may not be as expected.
```