### PR TITLE
BUGFIX: Use current context when warming up caches in FunctionalTestBootstrap

### DIFF
--- a/PhpUnit/FunctionalTestBootstrap.php
+++ b/PhpUnit/FunctionalTestBootstrap.php
@@ -21,7 +21,7 @@ $_SERVER['FLOW_ROOTPATH'] = dirname(__FILE__) . '/../../../';
 
 if (DIRECTORY_SEPARATOR === '/') {
 	// Fixes an issue with the autoloader, see FLOW-183
-	shell_exec('cd ' . escapeshellarg($_SERVER['FLOW_ROOTPATH']) . ' && FLOW_CONTEXT=Testing ./flow neos:cache:warmup');
+	shell_exec('cd ' . escapeshellarg($_SERVER['FLOW_ROOTPATH']) . ' && FLOW_CONTEXT=' . escapeshellarg($context) . ' ./flow neos:cache:warmup');
 }
 
 require_once($_SERVER['FLOW_ROOTPATH'] . 'Packages/Framework/Neos.Flow/Classes/Core/Bootstrap.php');


### PR DESCRIPTION
When running tests against a subcontext of Testing, e.g. `Testing/Functional`, warming the cache with just `Testing` may lead to logged exceptions depending on how Flow is configured.