### PR TITLE
TASK: Merge require-dev section from dev-collection composer manifest

### DIFF
--- a/TravisCi/ComposerManifestUpdater.php
+++ b/TravisCi/ComposerManifestUpdater.php
@@ -41,6 +41,12 @@ if(isset($composerManifest['require'][$targetRepository])) {
     exit(1);
 }
 
+// Merge dev requirements from dev-collection
+$buildComposerManifest = json_decode(file_get_contents('../../' . $travisRepoSlug . '/composer.json'), true);
+if (isset($buildComposerManifest['require-dev'])) {
+    $composerManifest['require-dev'] = array_merge($composerManifest['require-dev'], $buildComposerManifest['require-dev']);
+}
+
 $output = json_encode($composerManifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
 print_r($output);
 file_put_contents('composer.json', $output);


### PR DESCRIPTION
This is required to be able to define build requirements in the dev-collection, e.g. vimeo/psalm