### PR TITLE
TASK: Avoid duplicating require keys in require-dev or suggest

### DIFF
--- a/ComposerManifestMerger.php
+++ b/ComposerManifestMerger.php
@@ -14,7 +14,7 @@ if (!is_file('.composer.json')) {
  */
 function mergeArraySection($joinedManifest, $manifestData, $sectionKey)
 {
-    if ($sectionKey !== 'require' && isset($joinedManifest[$sectionKey])) {
+    if ($sectionKey !== 'require' && isset($joinedManifest['require'])) {
         return $joinedManifest;
     }
     if (isset($manifestData[$sectionKey])) {

--- a/ComposerManifestMerger.php
+++ b/ComposerManifestMerger.php
@@ -17,7 +17,9 @@ function mergeArraySection($joinedManifest, $manifestData, $sectionKey)
     if (isset($manifestData[$sectionKey])) {
         if ($sectionKey !== 'require') {
             $manifestData[$sectionKey] = array_diff_key($manifestData[$sectionKey], $joinedManifest['require']);
-            if ($manifestData[$sectionKey] === []) return $joinedManifest;
+            if ($manifestData[$sectionKey] === []) {
+                return $joinedManifest;
+            }
         }
         if (!isset($joinedManifest[$sectionKey])) {
             $joinedManifest[$sectionKey] = [];

--- a/ComposerManifestMerger.php
+++ b/ComposerManifestMerger.php
@@ -14,10 +14,11 @@ if (!is_file('.composer.json')) {
  */
 function mergeArraySection($joinedManifest, $manifestData, $sectionKey)
 {
-    if ($sectionKey !== 'require' && isset($joinedManifest['require'])) {
-        return $joinedManifest;
-    }
     if (isset($manifestData[$sectionKey])) {
+        if ($sectionKey !== 'require') {
+            $manifestData[$sectionKey] = array_diff_key($manifestData[$sectionKey], $joinedManifest['require']);
+            if ($manifestData[$sectionKey] === []) return $joinedManifest;
+        }
         if (!isset($joinedManifest[$sectionKey])) {
             $joinedManifest[$sectionKey] = [];
         }

--- a/ComposerManifestMerger.php
+++ b/ComposerManifestMerger.php
@@ -14,6 +14,9 @@ if (!is_file('.composer.json')) {
  */
 function mergeArraySection($joinedManifest, $manifestData, $sectionKey)
 {
+    if ($sectionKey !== 'require' && isset($joinedManifest[$sectionKey])) {
+        return $joinedManifest;
+    }
     if (isset($manifestData[$sectionKey])) {
         if (!isset($joinedManifest[$sectionKey])) {
             $joinedManifest[$sectionKey] = [];


### PR DESCRIPTION
This avoids adding a package as `require-dev` or `suggest` when it's already in `require`.

Resolves neos/flow-development-distribution#59
