### PR TITLE
BUGFIX: run renamed cache warmup command

### DIFF
--- a/PhpUnit/FunctionalTestBootstrap.php
+++ b/PhpUnit/FunctionalTestBootstrap.php
@@ -21,7 +21,7 @@ $_SERVER['FLOW_ROOTPATH'] = dirname(__FILE__) . '/../../../';
 
 if (DIRECTORY_SEPARATOR === '/') {
 	// Fixes an issue with the autoloader, see FLOW-183
-	shell_exec('cd ' . escapeshellarg($_SERVER['FLOW_ROOTPATH']) . ' && FLOW_CONTEXT=Testing ./flow neos:cache:warmup');
+	shell_exec('cd ' . escapeshellarg($_SERVER['FLOW_ROOTPATH']) . ' && FLOW_CONTEXT=Testing ./flow neos.flow:cache:warmup');
 }
 
 require_once($_SERVER['FLOW_ROOTPATH'] . 'Packages/Framework/Neos.Flow/Classes/Core/Bootstrap.php');


### PR DESCRIPTION
The PhpUnit/FunctionalTestBootstra.php is executing the wrong command, which doesn't exist. Instead it should run `neos.flow:cache:warmup`.

I'm not sure what is happening with the functional tests if this starts working again.