### PR TITLE
BUGFIX: Check if pr body is set

### DIFF
--- a/build-tools.php
+++ b/build-tools.php
@@ -245,7 +245,9 @@ class CreateChangeLogCommand extends GitLogCommand
         $changeLogEntry = ["`{$pr['title']} <{$pr['html_url']}>`_"];
         $this->addHeadlineMarkup($changeLogEntry, '-');
         $changeLogEntry[] = '';
-        $changeLogEntry[] = $this->cleanupPrMessage($pr['body']);
+        if (isset($pr['body'])) {
+            $changeLogEntry[] = $this->cleanupPrMessage($pr['body']);
+        }
         $this->extractAffectedPackages($changeLogEntry, $pr['merge_commit_sha']);
         $changeLogEntry[] = '';
         $message = implode("\n", $changeLogEntry);


### PR DESCRIPTION
Prevent this issue:

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to GitLogCommand::cleanupPrMessage() must be of the type string, null given, called in /Volumes/Development/Playground/neos-development-distribution/Build/BuildEssentials/build-tools.php on line 248 and defined in /Volumes/Development/Playground/neos-development-distribution/Build/BuildEssentials/GitLogCommand.php:78
```