### PR TITLE
TASK: Relax symfony version constraint to allow symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "neos/composer-plugin": "^2.0.0",
-        "symfony/console": "^5.1",
+        "symfony/console": "^5.1 || ^6.0",
         "guzzlehttp/guzzle": "^6.0 || ^7.0"
     },
     "extra": {


### PR DESCRIPTION
This currently still prevents using symfony 6 with neos 8.3