### PR TITLE
BUGFIX: writeln expects a string, fix possible null being passed

### DIFF
--- a/GitLogCommand.php
+++ b/GitLogCommand.php
@@ -199,7 +199,7 @@ abstract class GitLogCommand extends Command
 
     protected function commitLog(string $message, ?string $buildUrl): void
     {
-        $this->output->writeln(shell_exec("git add {$this->target}"));
+        $this->output->writeln((string)shell_exec("git add {$this->target}"));
         $commitCommand = "git commit -m \"$message\"";
         if ($buildUrl) {
             $commitCommand .= " -m \"See $buildUrl\"";


### PR DESCRIPTION
When `git add` is run and all is well, no output is emitted, leading to `shell_exec` returning `null`. This leads to an `Uncaught TypeError: Symfony\Component\Console\Output\Output::writeln(): Argument #1 ($messages) must be of type iterable|string, null given, called in /…/GitLogCommand.php on line 202 and defined in …` when generating the changelog.